### PR TITLE
Fix default JWT secret to satisfy validation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     sync_database_url: str = Field("sqlite:///./app.db", alias="SYNC_DATABASE_URL")
     access_token_expire_minutes: int = 30
     refresh_token_expire_days: int = 7
-    jwt_secret_key: str = Field("change-me", min_length=10)
+    jwt_secret_key: str = Field("change-me-please", min_length=10)
     jwt_algorithm: str = "HS256"
     allow_origins: list[str] = Field(default_factory=lambda: ["*"])
 


### PR DESCRIPTION
## Summary
- update the default JWT secret key so it satisfies the configured minimum length

## Testing
- `pytest` *(fails: missing optional dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e6ff7c6c8333bcacec02f4c0e75f