### PR TITLE
Adjust mobile layouts and fix analytics empty states

### DIFF
--- a/mobile/src/components/Card.tsx
+++ b/mobile/src/components/Card.tsx
@@ -30,8 +30,8 @@ export default function Card({ title, subtitle, right, children }: CardProps) {
 
 const styles = StyleSheet.create({
   card: {
-    borderRadius: 16,
-    padding: 16,
+    borderRadius: 12,
+    padding: 14,
     shadowColor: '#000',
     shadowOpacity: 0.05,
     shadowRadius: 12,
@@ -41,18 +41,18 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 12,
-    gap: 12
+    marginBottom: 8,
+    gap: 10
   },
   title: {
-    fontSize: 18,
+    fontSize: 16,
     fontWeight: '600'
   },
   subtitle: {
-    marginTop: 4,
-    fontSize: 14
+    marginTop: 2,
+    fontSize: 13
   },
   content: {
-    gap: 12
+    gap: 10
   }
 });

--- a/mobile/src/components/ChartContainer.tsx
+++ b/mobile/src/components/ChartContainer.tsx
@@ -27,9 +27,9 @@ export default function ChartContainer({ title, description, children }: ChartCo
 
 const styles = StyleSheet.create({
   container: {
-    borderRadius: 16,
-    padding: 16,
-    gap: 12
+    borderRadius: 12,
+    padding: 14,
+    gap: 10
   },
   header: {
     gap: 4
@@ -42,6 +42,6 @@ const styles = StyleSheet.create({
     fontSize: 13
   },
   chartArea: {
-    height: 220
+    height: 200
   }
 });

--- a/mobile/src/components/Fab.tsx
+++ b/mobile/src/components/Fab.tsx
@@ -41,13 +41,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    paddingHorizontal: 20,
-    paddingVertical: 14,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
     elevation: 4
   },
   label: {
     color: '#fff',
     fontWeight: '600',
-    fontSize: 16
+    fontSize: 15
   }
 });

--- a/mobile/src/components/ScreenShell.tsx
+++ b/mobile/src/components/ScreenShell.tsx
@@ -55,10 +55,10 @@ const styles = StyleSheet.create({
   },
   container: {
     paddingHorizontal: 16,
-    paddingVertical: 16,
-    gap: 16
+    paddingVertical: 12,
+    gap: 12
   },
   scrollContent: {
-    paddingBottom: 120
+    paddingBottom: 96
   }
 });

--- a/mobile/src/components/Stat.tsx
+++ b/mobile/src/components/Stat.tsx
@@ -31,10 +31,10 @@ const styles = StyleSheet.create({
     letterSpacing: 0.6
   },
   value: {
-    fontSize: 24,
+    fontSize: 20,
     fontWeight: '700'
   },
   trend: {
-    fontSize: 14
+    fontSize: 13
   }
 });

--- a/mobile/src/navigation/AppNavigator.tsx
+++ b/mobile/src/navigation/AppNavigator.tsx
@@ -27,9 +27,13 @@ function AppTabs() {
         tabBarStyle: {
           backgroundColor: theme.colors.card,
           borderTopColor: theme.colors.border,
-          height: 64,
-          paddingBottom: 10,
-          paddingTop: 10
+          height: 56,
+          paddingBottom: 6,
+          paddingTop: 6
+        },
+        tabBarLabelStyle: {
+          fontSize: 11,
+          marginTop: -2
         },
         tabBarActiveTintColor: theme.colors.primary,
         tabBarInactiveTintColor: theme.colors.muted,

--- a/mobile/src/screens/AnalyticsScreen.tsx
+++ b/mobile/src/screens/AnalyticsScreen.tsx
@@ -47,31 +47,43 @@ export default function AnalyticsScreen() {
         ))}
       </View>
       <Card title="Profit histogram" subtitle="Bucketed by month">
-        <VictoryChart theme={VictoryTheme.material} domainPadding={20} height={220}>
-          <VictoryBar
-            data={histogramData}
-            x="label"
-            y="value"
-            style={{ data: { fill: theme.colors.primary } }}
-          />
-        </VictoryChart>
+        {histogramData.length ? (
+          <VictoryChart theme={VictoryTheme.material} domainPadding={20} height={200}>
+            <VictoryBar
+              data={histogramData}
+              x="label"
+              y="value"
+              style={{ data: { fill: theme.colors.primary } }}
+            />
+          </VictoryChart>
+        ) : (
+          <Text style={[styles.emptyState, { color: theme.colors.muted }]}>Log cash sessions to see distribution.</Text>
+        )}
       </Card>
       <Card title="Game breakdown">
-        <VictoryPie
-          data={gameBreakdown}
-          colorScale={[theme.colors.primary, theme.colors.success, theme.colors.warning, theme.colors.muted]}
-          labels={({ datum }) => `${datum.x}: ${datum.y}`}
-          padAngle={2}
-        />
+        {gameBreakdown.length ? (
+          <VictoryPie
+            data={gameBreakdown}
+            colorScale={[theme.colors.primary, theme.colors.success, theme.colors.warning, theme.colors.muted]}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
+            padAngle={2}
+          />
+        ) : (
+          <Text style={[styles.emptyState, { color: theme.colors.muted }]}>No sessions recorded in this window.</Text>
+        )}
       </Card>
       <Card title="Day-of-week performance">
-        <VictoryBar
-          data={dowBreakdown}
-          x="label"
-          y="value"
-          style={{ data: { fill: theme.colors.success } }}
-          height={220}
-        />
+        {dowBreakdown.length ? (
+          <VictoryBar
+            data={dowBreakdown}
+            x="label"
+            y="value"
+            style={{ data: { fill: theme.colors.success } }}
+            height={200}
+          />
+        ) : (
+          <Text style={[styles.emptyState, { color: theme.colors.muted }]}>Track play to unlock weekday trends.</Text>
+        )}
       </Card>
       <Card title="Policy guidance" subtitle="Stake recommendation based on hourly volatility">
         <Text style={{ color: theme.colors.text, fontSize: 16 }}>{recommendation.summary}</Text>
@@ -174,13 +186,17 @@ function buildRecommendation(
 const styles = StyleSheet.create({
   rangeRow: {
     flexDirection: 'row',
-    gap: 12
+    gap: 10
   },
   rangeChip: {
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
     borderRadius: 12,
     borderWidth: 1,
     borderColor: 'rgba(148,163,184,0.4)'
+  },
+  emptyState: {
+    textAlign: 'center',
+    fontSize: 13
   }
 });

--- a/mobile/src/screens/SessionsScreen.tsx
+++ b/mobile/src/screens/SessionsScreen.tsx
@@ -70,7 +70,7 @@ export default function SessionsScreen() {
       <FlatList
         data={data}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 120, gap: 12 }}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 96, gap: 10 }}
         renderItem={({ item }) => (
           <Card
             title={item.venue ?? 'Unknown venue'}
@@ -103,11 +103,11 @@ export default function SessionsScreen() {
 const styles = StyleSheet.create({
   filterRow: {
     flexDirection: 'row',
-    gap: 12
+    gap: 10
   },
   filterChip: {
-    paddingHorizontal: 16,
-    paddingVertical: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
     borderRadius: 999,
     borderWidth: 1,
     borderColor: 'rgba(148,163,184,0.4)'

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -155,14 +155,14 @@ export default function SettingsScreen() {
 const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
-    gap: 12,
+    gap: 10,
     alignItems: 'center'
   },
   rowBetween: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingVertical: 8
+    paddingVertical: 6
   },
   inputGroup: {
     flex: 1
@@ -170,24 +170,24 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 13,
     color: '#6b7280',
-    marginBottom: 4
+    marginBottom: 3
   },
   input: {
     borderWidth: 1,
     borderRadius: 12,
     paddingHorizontal: 12,
-    paddingVertical: 10,
-    fontSize: 16
+    paddingVertical: 8,
+    fontSize: 15
   },
   inputSmall: {
     borderWidth: 1,
     borderRadius: 12,
     paddingHorizontal: 12,
-    paddingVertical: 6,
+    paddingVertical: 5,
     width: 80,
     textAlign: 'center'
   },
   exportButton: {
-    paddingVertical: 12
+    paddingVertical: 10
   }
 });

--- a/mobile/src/screens/SimulateScreen.tsx
+++ b/mobile/src/screens/SimulateScreen.tsx
@@ -171,11 +171,11 @@ function ResultStat({
 const styles = StyleSheet.create({
   segmentRow: {
     flexDirection: 'row',
-    gap: 12
+    gap: 10
   },
   segment: {
     flex: 1,
-    paddingVertical: 12,
+    paddingVertical: 10,
     borderRadius: 12,
     borderWidth: 1,
     borderColor: 'rgba(148,163,184,0.4)',
@@ -184,8 +184,8 @@ const styles = StyleSheet.create({
   formGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 12,
-    marginTop: 16
+    gap: 10,
+    marginTop: 14
   },
   inputWrapper: {
     width: '48%'
@@ -198,24 +198,24 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(148,163,184,0.12)',
     borderRadius: 12,
     paddingHorizontal: 12,
-    paddingVertical: 10,
-    fontSize: 16
+    paddingVertical: 8,
+    fontSize: 15
   },
   runButton: {
-    marginTop: 16,
+    marginTop: 14,
     borderRadius: 12,
-    paddingVertical: 14,
+    paddingVertical: 12,
     alignItems: 'center'
   },
   runLabel: {
     color: '#fff',
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: '600'
   },
   resultGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 16
+    gap: 14
   },
   resultStat: {
     width: '45%'


### PR DESCRIPTION
## Summary
- reduce tab bar height and shrink shared card spacing to better fit mobile layouts
- tweak screen-level paddings and controls so dashboard, sessions, simulate, and settings tabs feel less cramped
- guard analytics charts against empty data sets and show helpful guidance text instead of crashing

## Testing
- npm run lint *(fails: ESLint 9.34.0 requires flat config despite project shipping .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cb348329848333bb80c2be6b5ce46c